### PR TITLE
fix: remove hard-coded paths and patch overrides

### DIFF
--- a/bins/trueno-ublk/Cargo.toml
+++ b/bins/trueno-ublk/Cargo.toml
@@ -36,7 +36,7 @@ path = "examples/batched_benchmark.rs"
 
 [dependencies]
 # Internal crates (cuda disabled - API mismatch with trueno-gpu)
-trueno-zram-core = { version = "0.3.0", path = "../../crates/trueno-zram-core" }
+trueno-zram-core = { workspace = true }
 
 # CLI
 clap = { workspace = true }

--- a/bins/trueno-ublk/src/backend.rs
+++ b/bins/trueno-ublk/src/backend.rs
@@ -482,7 +482,7 @@ impl NvmeColdBackend {
     /// Create a new NVMe cold tier backend.
     ///
     /// # Arguments
-    /// * `base_path` - Directory for cold tier storage (e.g., `/mnt/nvme-raid0/trueno-cold`)
+    /// * `base_path` - Directory for cold tier storage (e.g., `$TRUENO_COLD_TIER_PATH` or `/tmp/trueno-cold`)
     ///
     /// Creates a sparse file `pages.dat` for storing uncompressed pages.
     pub fn new<P: AsRef<Path>>(base_path: P) -> Result<Self> {
@@ -712,7 +712,7 @@ impl TieredStorageManager {
     ///
     /// # Arguments
     /// * `kernel_device` - Optional path to kernel zram device (e.g., `/dev/zram0`)
-    /// * `nvme_cold_path` - Optional path to NVMe cold tier directory (e.g., `/mnt/nvme-raid0/trueno-cold`)
+    /// * `nvme_cold_path` - Optional path to NVMe cold tier directory (e.g., `$TRUENO_COLD_TIER_PATH` or `/tmp/trueno-cold`)
     /// * `routing_enabled` - Enable entropy-based routing
     pub fn new(
         kernel_device: Option<&Path>,

--- a/bins/trueno-ublk/src/cli/mod.rs
+++ b/bins/trueno-ublk/src/cli/mod.rs
@@ -282,7 +282,7 @@ pub struct CreateArgs {
     /// Used when --backend=tiered for high-entropy pages (H(X) > 7.5).
     /// High-entropy data skips compression and goes directly to NVMe.
     /// Directory will be created if it doesn't exist.
-    /// Example: /mnt/nvme-raid0/trueno-cold
+    /// Example: `$TRUENO_COLD_TIER_PATH` env var, or a path under `/tmp/trueno-cold`
     #[arg(long)]
     pub cold_tier: Option<String>,
 


### PR DESCRIPTION
## Summary

- Remove hard-coded `path = "../../crates/trueno-zram-core"` in `bins/trueno-ublk/Cargo.toml` — replaced with `workspace = true` to use the workspace-level definition
- Replace `/mnt/nvme-raid0` references in doc comments in `bins/trueno-ublk/src/backend.rs` and `bins/trueno-ublk/src/cli/mod.rs` with portable examples using `$TRUENO_COLD_TIER_PATH` env var or `/tmp/trueno-cold`

These changes are required for clean-room CI compatibility per the sovereign-stack-protected-branch-strategy.md (Section 5).

## Test plan

- [x] `cargo check` passes with no errors (192 pre-existing warnings, no new ones)
- [x] No `/mnt/nvme-raid0` references remain in any `.rs` files
- [x] No `[patch.crates-io]` path overrides remain in any `Cargo.toml` files
- [x] Workspace reference for `trueno-zram-core` is consistent with `workspace.dependencies`

Spec: sovereign-stack-protected-branch-strategy.md (Section 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)