### PR TITLE
fix(nightly): use -p trueno-zram-cli for binary build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,7 +72,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --bin trueno-zram --target ${{ matrix.target }}
+        run: cargo build --release -p trueno-zram-cli --target ${{ matrix.target }}
 
       - name: Package (unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- Fix nightly binary build by using `-p trueno-zram-cli` instead of `--bin trueno-zram`
- The `trueno-zram` binary lives in the `trueno-zram-cli` package, not the root workspace

## Test plan
- [ ] Manual dispatch nightly workflow after merge

Generated with [Claude Code](https://claude.com/claude-code)